### PR TITLE
Slice append fix

### DIFF
--- a/coordinate_pair.go
+++ b/coordinate_pair.go
@@ -21,7 +21,7 @@ func SortCoordinatePairs(cp []CoordinatePair) {
 func SlicesToCoordinatePairs(x, y []float64) []CoordinatePair {
 	cp := make([]CoordinatePair, len(x))
 	for i := 0; i < len(x); i++ {
-		cp = append(cp, CoordinatePair{X: x[i], Y: y[i]})
+		cp[i] = CoordinatePair{X: x[i], Y: y[i]}
 	}
 	return cp
 }

--- a/differentiate/backward_test.go
+++ b/differentiate/backward_test.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/DzananGanic/numericalgo/differentiate"
+	"github.com/teivah/numericalgo/differentiate"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/differentiate/central_test.go
+++ b/differentiate/central_test.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/DzananGanic/numericalgo/differentiate"
+	"github.com/teivah/numericalgo/differentiate"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/differentiate/forward_test.go
+++ b/differentiate/forward_test.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/DzananGanic/numericalgo/differentiate"
+	"github.com/teivah/numericalgo/differentiate"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/fit/exponential/exponential.go
+++ b/fit/exponential/exponential.go
@@ -1,7 +1,7 @@
 package exponential
 
 import (
-	"github.com/DzananGanic/numericalgo"
+	"github.com/teivah/numericalgo"
 )
 
 // Exponential type fits two vectors x and y, finds the appropriate coefficients and predicts the value such that y=p*e^(q*x) is the best approximation of the given data in a sense of the least square error.

--- a/fit/exponential/exponential_test.go
+++ b/fit/exponential/exponential_test.go
@@ -3,9 +3,9 @@ package exponential_test
 import (
 	"testing"
 
-	"github.com/DzananGanic/numericalgo"
-	"github.com/DzananGanic/numericalgo/fit"
-	"github.com/DzananGanic/numericalgo/fit/exponential"
+	"github.com/teivah/numericalgo"
+	"github.com/teivah/numericalgo/fit"
+	"github.com/teivah/numericalgo/fit/exponential"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/fit/fit.go
+++ b/fit/fit.go
@@ -1,7 +1,7 @@
 package fit
 
 import (
-	"github.com/DzananGanic/numericalgo"
+	"github.com/teivah/numericalgo"
 )
 
 type predictor interface {

--- a/fit/linear/linear.go
+++ b/fit/linear/linear.go
@@ -1,7 +1,7 @@
 package linear
 
 import (
-	"github.com/DzananGanic/numericalgo"
+	"github.com/teivah/numericalgo"
 )
 
 // Linear type fits two vectors x and y, finds the appropriate coefficients and predicts the value such that y=p+qx is the best approximation of the given data in a sense of the least square error.

--- a/fit/linear/linear_test.go
+++ b/fit/linear/linear_test.go
@@ -3,9 +3,9 @@ package linear_test
 import (
 	"testing"
 
-	"github.com/DzananGanic/numericalgo"
-	"github.com/DzananGanic/numericalgo/fit"
-	"github.com/DzananGanic/numericalgo/fit/linear"
+	"github.com/teivah/numericalgo"
+	"github.com/teivah/numericalgo/fit"
+	"github.com/teivah/numericalgo/fit/linear"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/fit/poly/poly.go
+++ b/fit/poly/poly.go
@@ -3,7 +3,7 @@ package poly
 import (
 	"math"
 
-	"github.com/DzananGanic/numericalgo"
+	"github.com/teivah/numericalgo"
 )
 
 // Poly type fits two vectors x and y, finds the appropriate coefficients and predicts the value such that y=p1+p2*x+p3*x^2+...+p(n+1)*x^n is the best approximation of the given data in a sense of the least square error.

--- a/fit/poly/poly_test.go
+++ b/fit/poly/poly_test.go
@@ -3,10 +3,10 @@ package poly_test
 import (
 	"testing"
 
-	"github.com/DzananGanic/numericalgo/fit"
+	"github.com/teivah/numericalgo/fit"
 
-	"github.com/DzananGanic/numericalgo"
-	"github.com/DzananGanic/numericalgo/fit/poly"
+	"github.com/teivah/numericalgo"
+	"github.com/teivah/numericalgo/fit/poly"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/integrate/simpson.go
+++ b/integrate/simpson.go
@@ -3,7 +3,7 @@ package integrate
 import (
 	"fmt"
 
-	"github.com/DzananGanic/numericalgo"
+	"github.com/teivah/numericalgo"
 )
 
 // Simpson is a function which accepts function, left, right bounds and n number of subdivisions. It returns the integration

--- a/integrate/simpson_test.go
+++ b/integrate/simpson_test.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/DzananGanic/numericalgo/integrate"
+	"github.com/teivah/numericalgo/integrate"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/integrate/trapezoid.go
+++ b/integrate/trapezoid.go
@@ -3,7 +3,7 @@ package integrate
 import (
 	"fmt"
 
-	"github.com/DzananGanic/numericalgo"
+	"github.com/teivah/numericalgo"
 )
 
 // Trapezoid is a function which accepts function, left, right bounds and n number of subdivisions. It returns the integration

--- a/integrate/trapezoid_test.go
+++ b/integrate/trapezoid_test.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/DzananGanic/numericalgo/integrate"
+	"github.com/teivah/numericalgo/integrate"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/interpolate/base.go
+++ b/interpolate/base.go
@@ -3,7 +3,7 @@ package interpolate
 import (
 	"fmt"
 
-	"github.com/DzananGanic/numericalgo"
+	"github.com/teivah/numericalgo"
 )
 
 // Base type provides the base functionality for any interpolation type

--- a/interpolate/lagrange/lagrange.go
+++ b/interpolate/lagrange/lagrange.go
@@ -3,7 +3,7 @@ package lagrange
 import (
 	"fmt"
 
-	"github.com/DzananGanic/numericalgo/interpolate"
+	"github.com/teivah/numericalgo/interpolate"
 )
 
 // Lagrange provides the basic functionality for lagrange interpolation.

--- a/interpolate/lagrange/lagrange_test.go
+++ b/interpolate/lagrange/lagrange_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/DzananGanic/numericalgo/interpolate"
-	"github.com/DzananGanic/numericalgo/interpolate/lagrange"
+	"github.com/teivah/numericalgo/interpolate"
+	"github.com/teivah/numericalgo/interpolate/lagrange"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/interpolate/linear/linear.go
+++ b/interpolate/linear/linear.go
@@ -3,7 +3,7 @@ package linear
 import (
 	"fmt"
 
-	"github.com/DzananGanic/numericalgo/interpolate"
+	"github.com/teivah/numericalgo/interpolate"
 )
 
 // Linear provides the basic functionality for linear interpolation.

--- a/interpolate/linear/linear.go
+++ b/interpolate/linear/linear.go
@@ -50,7 +50,18 @@ func (li *Linear) findNearestNeighbors(val float64, l, r int) (int, int) {
 	if (val >= li.XYPairs[middle-1].X) && (val <= li.XYPairs[middle].X) {
 		return middle - 1, middle
 	} else if val < li.XYPairs[middle-1].X {
+		x := middle - 2
+		if x == r {
+			return middle - 1, middle
+		}
+
 		return li.findNearestNeighbors(val, l, middle-2)
 	}
+
+	x := middle + 1
+	if x == l {
+		return middle - 1, middle
+	}
+
 	return li.findNearestNeighbors(val, middle+1, r)
 }

--- a/interpolate/linear/linear_test.go
+++ b/interpolate/linear/linear_test.go
@@ -5,8 +5,8 @@ import (
 
 	"fmt"
 
-	"github.com/DzananGanic/numericalgo/interpolate"
-	"github.com/DzananGanic/numericalgo/interpolate/linear"
+	"github.com/teivah/numericalgo/interpolate"
+	"github.com/teivah/numericalgo/interpolate/linear"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/matrix_test.go
+++ b/matrix_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/DzananGanic/numericalgo"
+	"github.com/teivah/numericalgo"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/root/bisection_test.go
+++ b/root/bisection_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/DzananGanic/numericalgo/root"
+	"github.com/teivah/numericalgo/root"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/root/newton.go
+++ b/root/newton.go
@@ -1,6 +1,6 @@
 package root
 
-import "github.com/DzananGanic/numericalgo/differentiate"
+import "github.com/teivah/numericalgo/differentiate"
 
 // Newton receives three parameters. First parameter is the function we want to find root of. Second one is the initial guess (reasonably close to the true root). Third one is the number of iterations for the newton method. The Newton function returns the result as a float64, and the error.
 func Newton(f func(float64) float64, x0 float64, iter int) (float64, error) {

--- a/root/newton_test.go
+++ b/root/newton_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/DzananGanic/numericalgo/root"
+	"github.com/teivah/numericalgo/root"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/vector_test.go
+++ b/vector_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/DzananGanic/numericalgo"
+	"github.com/teivah/numericalgo"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Hey,

I found a bug in the `SliceToCoordinatePairs` function. Let's say x and y had a length of 40. The function was creating a slice of 40 empty elements + 40 CoordinatePair.