### PR TITLE
correct runaway during middle detection

### DIFF
--- a/interpolate/linear/linear.go
+++ b/interpolate/linear/linear.go
@@ -50,7 +50,7 @@ func (li *Linear) findNearestNeighbors(val float64, l, r int) (int, int) {
 	if (val >= li.XYPairs[middle-1].X) && (val <= li.XYPairs[middle].X) {
 		return middle - 1, middle
 	} else if val < li.XYPairs[middle-1].X {
-		return li.findNearestNeighbors(val, l, middle-2)
+		return li.findNearestNeighbors(val, l, middle-1)
 	}
 	return li.findNearestNeighbors(val, middle+1, r)
 }

--- a/interpolate/linear/linear_test.go
+++ b/interpolate/linear/linear_test.go
@@ -52,6 +52,13 @@ func TestLinearCanInterpolateSingleValue(t *testing.T) {
 			expectedEstimate:   3.1566666666666663,
 			expectedError:      nil,
 		},
+		"basic linear single-valued interpolation - middle detection err": {
+			x:                  []float64{1100, 1200, 1230, 1260, 1280, 1300, 1320, 1340, 1380, 1440, 1590},
+			y:                  []float64{0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100},
+			valueToInterpolate: 1265,
+			expectedEstimate:   32.5,
+			expectedError:      nil,
+		},
 		"testing binary search for nearest neighbor - case where the interpolation value should be between indexes 0 and 1": {
 			x:                  []float64{1.3, 1.8, 2.5, 3.1, 3.8, 4.4, 4.9, 5.5, 6.2},
 			y:                  []float64{3.37, 4.45, 4.81, 3.96, 3.31, 2.72, 3.02, 3.43, 4.07},


### PR DESCRIPTION
I have the issue, that I get a stack trace when using certain values for the linear interpolation.
During debugging I found something in the `findNearestNeighbors` method which seems to be a bug.
The PR solves the issue for me and all the tests still passing.

I've added a test for my issue as well.