### PR TITLE
coordinate pair to long by using append

### DIFF
--- a/coordinate_pair.go
+++ b/coordinate_pair.go
@@ -21,7 +21,7 @@ func SortCoordinatePairs(cp []CoordinatePair) {
 func SlicesToCoordinatePairs(x, y []float64) []CoordinatePair {
 	cp := make([]CoordinatePair, len(x))
 	for i := 0; i < len(x); i++ {
-		cp = append(cp, CoordinatePair{X: x[i], Y: y[i]})
+		cp[i] = CoordinatePair{X: x[i], Y: y[i]}
 	}
 	return cp
 }

--- a/interpolate/linear/linear.go
+++ b/interpolate/linear/linear.go
@@ -21,6 +21,16 @@ func New() *Linear {
 func (li *Linear) Interpolate(val float64) float64 {
 	var est float64
 
+	// early return if we are already at the boundaries
+	if val == li.XYPairs[0].X {
+		est = li.XYPairs[0].Y
+		return est
+	}
+	if val == li.XYPairs[len(li.XYPairs)-1].X {
+		est = li.XYPairs[len(li.XYPairs)-1].Y
+		return est
+	}
+
 	l, r := li.findNearestNeighbors(val, 0, len(li.XYPairs)-1)
 
 	lX := li.XYPairs[l].X

--- a/interpolate/linear/linear.go
+++ b/interpolate/linear/linear.go
@@ -50,7 +50,7 @@ func (li *Linear) findNearestNeighbors(val float64, l, r int) (int, int) {
 	if (val >= li.XYPairs[middle-1].X) && (val <= li.XYPairs[middle].X) {
 		return middle - 1, middle
 	} else if val < li.XYPairs[middle-1].X {
-		return li.findNearestNeighbors(val, l, middle-2)
+		return li.findNearestNeighbors(val, l, middle-1)
 	}
 	return li.findNearestNeighbors(val, middle+1, r)
 }

--- a/interpolate/linear/linear_test.go
+++ b/interpolate/linear/linear_test.go
@@ -59,6 +59,20 @@ func TestLinearCanInterpolateSingleValue(t *testing.T) {
 			expectedEstimate:   32.5,
 			expectedError:      nil,
 		},
+		"basic linear single-valued interpolation - first element": {
+			x:                  []float64{1100, 1200, 1230, 1260, 1280, 1300, 1320, 1340, 1380, 1440, 1590},
+			y:                  []float64{0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100},
+			valueToInterpolate: 1100,
+			expectedEstimate:   0,
+			expectedError:      nil,
+		},
+		"basic linear single-valued interpolation - last element": {
+			x:                  []float64{1100, 1200, 1230, 1260, 1280, 1300, 1320, 1340, 1380, 1440, 1590},
+			y:                  []float64{0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100},
+			valueToInterpolate: 1590,
+			expectedEstimate:   100,
+			expectedError:      nil,
+		},
 		"testing binary search for nearest neighbor - case where the interpolation value should be between indexes 0 and 1": {
 			x:                  []float64{1.3, 1.8, 2.5, 3.1, 3.8, 4.4, 4.9, 5.5, 6.2},
 			y:                  []float64{3.37, 4.45, 4.81, 3.96, 3.31, 2.72, 3.02, 3.43, 4.07},

--- a/interpolate/linear/linear_test.go
+++ b/interpolate/linear/linear_test.go
@@ -52,6 +52,13 @@ func TestLinearCanInterpolateSingleValue(t *testing.T) {
 			expectedEstimate:   3.1566666666666663,
 			expectedError:      nil,
 		},
+		"basic linear single-valued interpolation - middle detection err": {
+			x:                  []float64{1100, 1200, 1230, 1260, 1280, 1300, 1320, 1340, 1380, 1440, 1590},
+			y:                  []float64{0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100},
+			valueToInterpolate: 1265,
+			expectedEstimate:   32.5,
+			expectedError:      nil,
+		},
 		"testing binary search for nearest neighbor - case where the interpolation value should be between indexes 0 and 1": {
 			x:                  []float64{1.3, 1.8, 2.5, 3.1, 3.8, 4.4, 4.9, 5.5, 6.2},
 			y:                  []float64{3.37, 4.45, 4.81, 3.96, 3.31, 2.72, 3.02, 3.43, 4.07},


### PR DESCRIPTION
li.XYPairs is created with the length of x and then values are appended which will result in a length twice the size needed.
This will fix it.